### PR TITLE
Remove yhatt from Sponsoring section

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,5 +37,4 @@ I'm a software engineer in Kumamoto, Japan.
 - Biome: https://github.com/sponsors/biomejs
 - Homebrew: https://github.com/sponsors/Homebrew
 - Python: https://github.com/sponsors/python
-- yhatt (Yuki Hattori): https://github.com/sponsors/yhatt
 - Vite: https://github.com/sponsors/vitejs


### PR DESCRIPTION
## Summary
- Remove yhatt (Yuki Hattori) from the Sponsoring section in README.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)