### PR TITLE
Add antfu to Sponsoring section

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ I'm a software engineer in Kumamoto, Japan.
 - Zenn: https://zenn.dev/shige
 
 #### 💖 Sponsoring
+- antfu (Anthony Fu): https://github.com/sponsors/antfu
 - Biome: https://github.com/sponsors/biomejs
 - Homebrew: https://github.com/sponsors/Homebrew
 - Python: https://github.com/sponsors/python


### PR DESCRIPTION
## Summary
- Add antfu (Anthony Fu) to the Sponsoring section in README.md

## Refs
- https://codenote.net/en/posts/antfu-github-sponsors/

🤖 Generated with [Claude Code](https://claude.com/claude-code)