### PR TITLE
Add aquaproj to Sponsoring section

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ I'm a software engineer in Kumamoto, Japan.
 
 #### 💖 Sponsoring
 - antfu (Anthony Fu): https://github.com/sponsors/antfu
+- aquaproj: https://github.com/sponsors/aquaproj
 - Biome: https://github.com/sponsors/biomejs
 - Homebrew: https://github.com/sponsors/Homebrew
 - Python: https://github.com/sponsors/python


### PR DESCRIPTION
## Summary
- Add aquaproj to the Sponsoring section of the README, keeping the list alphabetical

## Test plan
- [x] README renders correctly with the new entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)